### PR TITLE
This PR adds the Watchdog node 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,6 @@ install(TARGETS
 add_executable(sas_robot_watchdog_commander_node
     src/sas_robot_watchdog_commander_node.cpp)
 target_link_libraries(sas_robot_watchdog_commander_node
-    dqrobotics
-    dqrobotics-interface-json11
     ${PROJECT_NAME}
     Eigen3::Eigen
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,21 @@ install(TARGETS
 ##END## CPP BINARY #####
 
 ##### CPP BINARY #####
+add_executable(sas_robot_watchdog_commander_node
+    src/sas_robot_watchdog_commander_node.cpp)
+target_link_libraries(sas_robot_watchdog_commander_node
+    dqrobotics
+    dqrobotics-interface-json11
+    ${PROJECT_NAME}
+    Eigen3::Eigen
+    )
+install(TARGETS
+  sas_robot_watchdog_commander_node
+  DESTINATION lib/${PROJECT_NAME})
+
+##END## CPP BINARY #####
+
+##### CPP BINARY #####
 
 add_executable(sas_robot_driver_ros_example
     src/examples/sas_robot_driver_ros_example.cpp)

--- a/src/sas_robot_driver_ros.cpp
+++ b/src/sas_robot_driver_ros.cpp
@@ -110,11 +110,12 @@ int RobotDriverROS::control_loop()
                     robot_driver_->watchdog_start(period);
                     //--- For developers: Do not put more code after this point---//
                 }
-                try{
-                    robot_driver_->watchdog_trigger(robot_driver_server_.get_watchdog_time_point_from_the_client(),
-                                                    robot_driver_server_.get_watchdog_time_point_from_the_server(),
-                                                    robot_driver_server_.get_watchdog_trigger_status());
-                }catch(...){}
+                // Any exception from the watchdog thread control loop will be rethrown by watchdog_trigger(), and
+                // consequently the main control loop must stop.
+                robot_driver_->watchdog_trigger(robot_driver_server_.get_watchdog_time_point_from_the_client(),
+                                                robot_driver_server_.get_watchdog_time_point_from_the_server(),
+                                                robot_driver_server_.get_watchdog_trigger_status());
+
             }
 
 

--- a/src/sas_robot_driver_ros_composer_node.cpp
+++ b/src/sas_robot_driver_ros_composer_node.cpp
@@ -1,5 +1,5 @@
 /*
-# Copyright (c) 2016-2022 Murilo Marques Marinodeo
+# Copyright (c) 2016-2025 Murilo Marques Marinho
 #
 #    This file is part of sas_robot_driver.
 #

--- a/src/sas_robot_watchdog_commander_node.cpp
+++ b/src/sas_robot_watchdog_commander_node.cpp
@@ -1,0 +1,73 @@
+/*
+# Copyright (c) 2016-2025 Murilo Marques Marinho
+#
+#    This file is part of sas_robot_driver.
+#
+#    sas_robot_driver is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Lesser General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    sas_robot_driver is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public License
+#    along with sas_robot_driver.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ################################################################
+#
+#   Author: Juan Jose Quiroz Omana, email: juanjose.quirozomana@manchester.ac.uk
+#
+# ################################################################*/
+
+#include <rclcpp/rclcpp.hpp>
+#include <sas_core/sas_clock.hpp>
+#include <sas_common/sas_common.hpp>
+#include <sas_robot_driver/sas_robot_driver_client.hpp>
+#include <dqrobotics/utils/DQ_Math.h>
+
+using namespace DQ_robotics;
+
+#include<signal.h>
+static std::atomic_bool kill_this_process(false);
+void sig_int_handler(int)
+{
+    kill_this_process = true;
+}
+
+int main(int argc, char** argv)
+{
+    if(signal(SIGINT, sig_int_handler) == SIG_ERR)
+        throw std::runtime_error("::Error setting the signal int handler.");
+
+
+    rclcpp::init(argc,argv,rclcpp::InitOptions(),rclcpp::SignalHandlerOptions::None);
+    auto node = std::make_shared<rclcpp::Node>("sas_robot_watchdog_commander_node");
+
+    double thread_sampling_time_sec;
+    sas::get_ros_parameter(node, "thread_sampling_time_sec", thread_sampling_time_sec);
+    std::string robot_name;
+    sas::get_ros_parameter(node,"robot_name", robot_name);
+    RCLCPP_INFO_STREAM_ONCE(node->get_logger(), "::thread_sampling_time_sec: " + std::to_string(thread_sampling_time_sec));
+    RCLCPP_INFO_STREAM_ONCE(node->get_logger(), "::robot_name: " + robot_name);
+    RCLCPP_INFO_STREAM_ONCE(node->get_logger(), "::Parameters OK.");
+
+    // Initialize the RobotDriverClient
+    sas::RobotDriverClient rdi(node, robot_name);
+
+
+    sas::Clock clock{thread_sampling_time_sec};
+    clock.init();
+    // For some iterations. Note that this can be stopped with CTRL+C.
+    while (!kill_this_process)
+    {
+        clock.update_and_sleep();
+        RCLCPP_INFO_STREAM_ONCE(node->get_logger(),"Watchdog status: true");
+        rdi.send_watchdog_trigger(true);
+        rclcpp::spin_some(node);
+    }
+
+
+}


### PR DESCRIPTION
Hi @mmmarinho, 

This PR adds the Watchdog node.
 
Usage:

```python
"""
This file is based on the sas_kuka_control_template
https://github.com/MarinhoLab/sas_kuka_control_template/blob/main/launch/simulation_example_py_launch.py

"""
from launch import LaunchDescription
from launch_ros.actions import Node


def generate_launch_description():

    return LaunchDescription([
        Node(
            package='sas_robot_driver',
            executable='sas_robot_watchdog_commander_node',
            namespace="sas",
            output="screen",
            parameters=[{
                "robot_name":"dummy_1",
                "thread_sampling_time_sec": 0.1,    
            }]
        ),

    ])
```

In addition, I removed the try-catch block in the part that calls `robot_driver_->watchdog_trigger`.  In this case, it is desired to interrupt the main control loop if an exception is thrown by the robot driver due to the watchdog.

Kind regards, 

Juancho