### PR TITLE
This PR fixes the blacklist feature

### DIFF
--- a/src/sas_robot_driver_client.cpp
+++ b/src/sas_robot_driver_client.cpp
@@ -128,35 +128,40 @@ void RobotDriverClient::send_target_joint_positions(const VectorXd &target_joint
 {
     std_msgs::msg::Float64MultiArray ros_msg;
     ros_msg.data = vectorxd_to_std_vector_double(target_joint_positions);
-    publisher_target_joint_positions_->publish(ros_msg);
+    if (publisher_target_joint_positions_)
+        publisher_target_joint_positions_->publish(ros_msg);
 }
 
 void RobotDriverClient::send_target_joint_velocities(const VectorXd &target_joint_velocities)
 {
     std_msgs::msg::Float64MultiArray ros_msg;
     ros_msg.data = vectorxd_to_std_vector_double(target_joint_velocities);
-    publisher_target_joint_velocities_->publish(ros_msg);
+    if(publisher_target_joint_velocities_)
+        publisher_target_joint_velocities_->publish(ros_msg);
 }
 
 void RobotDriverClient::send_target_joint_forces(const VectorXd &target_joint_efforts)
 {
     std_msgs::msg::Float64MultiArray ros_msg;
     ros_msg.data = vectorxd_to_std_vector_double(target_joint_efforts);
-    publisher_target_joint_forces_->publish(ros_msg);
+    if (publisher_target_joint_forces_)
+        publisher_target_joint_forces_->publish(ros_msg);
 }
 
 void RobotDriverClient::send_homing_signal(const VectorXi &homing_signal)
 {
     std_msgs::msg::Int32MultiArray ros_msg;
     ros_msg.data = vectorxi_to_std_vector_int(homing_signal);
-    publisher_homing_signal_->publish(ros_msg);
+    if (publisher_homing_signal_)
+        publisher_homing_signal_->publish(ros_msg);
 }
 
 void RobotDriverClient::send_clear_positions_signal(const VectorXi &clear_positions_signal)
 {
     std_msgs::msg::Int32MultiArray ros_msg;
     ros_msg.data = vectorxi_to_std_vector_int(clear_positions_signal);
-    publisher_clear_positions_signal_->publish(ros_msg);
+    if (publisher_clear_positions_signal_)
+        publisher_clear_positions_signal_->publish(ros_msg);
 }
 
 /**
@@ -169,7 +174,8 @@ void RobotDriverClient::send_watchdog_trigger(const bool& watchdog_trigger_statu
     ros_msg.header = std_msgs::msg::Header();
     ros_msg.header.stamp = rclcpp::Clock().now();
     ros_msg.status = watchdog_trigger_status;
-    publisher_watchdog_trigger_->publish(ros_msg);
+    if (publisher_watchdog_trigger_)
+        publisher_watchdog_trigger_->publish(ros_msg);
 }
 
 VectorXd RobotDriverClient::get_joint_positions() const

--- a/src/sas_robot_driver_client.cpp
+++ b/src/sas_robot_driver_client.cpp
@@ -126,42 +126,65 @@ RobotDriverClient::RobotDriverClient(const std::shared_ptr<Node> &node,
 
 void RobotDriverClient::send_target_joint_positions(const VectorXd &target_joint_positions)
 {
-    std_msgs::msg::Float64MultiArray ros_msg;
-    ros_msg.data = vectorxd_to_std_vector_double(target_joint_positions);
+
     if (publisher_target_joint_positions_)
+    {
+        std_msgs::msg::Float64MultiArray ros_msg;
+        ros_msg.data = vectorxd_to_std_vector_double(target_joint_positions);
         publisher_target_joint_positions_->publish(ros_msg);
+    }
+    else
+        throw std::runtime_error("RobotDriverClient::"+std::string(__FUNCTION__)+"::This method is blacklisted");
 }
 
 void RobotDriverClient::send_target_joint_velocities(const VectorXd &target_joint_velocities)
 {
-    std_msgs::msg::Float64MultiArray ros_msg;
-    ros_msg.data = vectorxd_to_std_vector_double(target_joint_velocities);
     if(publisher_target_joint_velocities_)
+    {
+        std_msgs::msg::Float64MultiArray ros_msg;
+        ros_msg.data = vectorxd_to_std_vector_double(target_joint_velocities);
         publisher_target_joint_velocities_->publish(ros_msg);
+    }
+    else
+        throw std::runtime_error("RobotDriverClient::"+std::string(__FUNCTION__)+"::This method is blacklisted");
+
 }
 
 void RobotDriverClient::send_target_joint_forces(const VectorXd &target_joint_efforts)
 {
-    std_msgs::msg::Float64MultiArray ros_msg;
-    ros_msg.data = vectorxd_to_std_vector_double(target_joint_efforts);
+
     if (publisher_target_joint_forces_)
+    {
+        std_msgs::msg::Float64MultiArray ros_msg;
+        ros_msg.data = vectorxd_to_std_vector_double(target_joint_efforts);
         publisher_target_joint_forces_->publish(ros_msg);
+    }
+    else
+        throw std::runtime_error("RobotDriverClient::"+std::string(__FUNCTION__)+"::This method is blacklisted");
 }
 
 void RobotDriverClient::send_homing_signal(const VectorXi &homing_signal)
 {
-    std_msgs::msg::Int32MultiArray ros_msg;
-    ros_msg.data = vectorxi_to_std_vector_int(homing_signal);
     if (publisher_homing_signal_)
+    {
+        std_msgs::msg::Int32MultiArray ros_msg;
+        ros_msg.data = vectorxi_to_std_vector_int(homing_signal);
         publisher_homing_signal_->publish(ros_msg);
+    }
+    else
+        throw std::runtime_error("RobotDriverClient::"+std::string(__FUNCTION__)+"::This method is blacklisted");
 }
 
 void RobotDriverClient::send_clear_positions_signal(const VectorXi &clear_positions_signal)
 {
-    std_msgs::msg::Int32MultiArray ros_msg;
-    ros_msg.data = vectorxi_to_std_vector_int(clear_positions_signal);
     if (publisher_clear_positions_signal_)
+    {
+        std_msgs::msg::Int32MultiArray ros_msg;
+        ros_msg.data = vectorxi_to_std_vector_int(clear_positions_signal);
         publisher_clear_positions_signal_->publish(ros_msg);
+    }
+    else
+        throw std::runtime_error("RobotDriverClient::"+std::string(__FUNCTION__)+"::This method is blacklisted");
 }
 
 /**
@@ -170,12 +193,17 @@ void RobotDriverClient::send_clear_positions_signal(const VectorXi &clear_positi
  */
 void RobotDriverClient::send_watchdog_trigger(const bool& watchdog_trigger_status)
 {
-    sas_msgs::msg::WatchdogTrigger ros_msg;
-    ros_msg.header = std_msgs::msg::Header();
-    ros_msg.header.stamp = rclcpp::Clock().now();
-    ros_msg.status = watchdog_trigger_status;
+
     if (publisher_watchdog_trigger_)
+    {
+        sas_msgs::msg::WatchdogTrigger ros_msg;
+        ros_msg.header = std_msgs::msg::Header();
+        ros_msg.header.stamp = rclcpp::Clock().now();
+        ros_msg.status = watchdog_trigger_status;
         publisher_watchdog_trigger_->publish(ros_msg);
+    }
+    else
+        throw std::runtime_error("RobotDriverClient::"+std::string(__FUNCTION__)+"::This method is blacklisted");
 }
 
 VectorXd RobotDriverClient::get_joint_positions() const

--- a/src/sas_robot_driver_client.cpp
+++ b/src/sas_robot_driver_client.cpp
@@ -81,12 +81,12 @@ RobotDriverClient::RobotDriverClient(const std::shared_ptr<Node> &node,
                                      const std::vector<MODE_BLACKLIST_FLAG>& blacklisted_modes):
     sas::Object("sas::RobotDriverClient"),
     node_(node),
-    topic_prefix_(topic_prefix == "GET_FROM_NODE"? node->get_name() : topic_prefix),
-    blacklisted_modes_(blacklisted_modes)
+    blacklisted_modes_(blacklisted_modes),
+    topic_prefix_(topic_prefix == "GET_FROM_NODE"? node->get_name() : topic_prefix)
 {
     RCLCPP_INFO_STREAM(node_->get_logger(),"::Initializing RobotDriverClient with prefix " + topic_prefix);
 
-    if(mode_not_in_blacklist(JOINT_CONTROL,blacklisted_modes_))
+    if(mode_not_in_blacklist(MODE_BLACKLIST_FLAG::JOINT_CONTROL,blacklisted_modes_))
     {
         publisher_target_joint_positions_ = node->create_publisher<std_msgs::msg::Float64MultiArray>(topic_prefix + "/set/target_joint_positions",1);
         publisher_target_joint_velocities_ = node->create_publisher<std_msgs::msg::Float64MultiArray>(topic_prefix + "/set/target_joint_velocities",1);
@@ -95,12 +95,12 @@ RobotDriverClient::RobotDriverClient(const std::shared_ptr<Node> &node,
         publisher_clear_positions_signal_ = node->create_publisher<std_msgs::msg::Int32MultiArray>(topic_prefix + "/set/clear_positions_signal",1);
     }
 
-    if(mode_not_in_blacklist(WATCHDOG_CONTROL,blacklisted_modes_))
+    if(mode_not_in_blacklist(MODE_BLACKLIST_FLAG::WATCHDOG_CONTROL,blacklisted_modes_))
     {
         publisher_watchdog_trigger_ = node->create_publisher<sas_msgs::msg::WatchdogTrigger>(topic_prefix + "/set/watchdog_trigger", 1);
     }
 
-    if(mode_not_in_blacklist(JOINT_MONITORING,blacklisted_modes_))
+    if(mode_not_in_blacklist(MODE_BLACKLIST_FLAG::JOINT_MONITORING,blacklisted_modes_))
     {
         subscriber_joint_states_ = node->create_subscription<sensor_msgs::msg::JointState>(
                     topic_prefix + "/get/joint_states", 1, std::bind(&RobotDriverClient::_callback_joint_states, this, _1)

--- a/src/sas_robot_driver_client.cpp
+++ b/src/sas_robot_driver_client.cpp
@@ -70,10 +70,17 @@ void RobotDriverClient::_callback_home_states(const std_msgs::msg::Int32MultiArr
     home_states_ = std_vector_int_to_vectorxi(msg.data);
 }
 
-bool mode_not_in_blacklist(const RobotDriverClient::MODE_BLACKLIST_FLAG& mode,
-                           const std::vector<RobotDriverClient::MODE_BLACKLIST_FLAG>& l)
+/**
+ * @brief mode_in_blacklist returns true if the specified mode is listed on the list of flags
+ * @param mode The flag mode
+ * @param list of flags the list of the flags
+ * @return returns true if the specified mode is listed on list of flags. False otherwise.
+ */
+bool mode_in_blacklist(const RobotDriverClient::MODE_BLACKLIST_FLAG& mode,
+                       const std::vector<RobotDriverClient::MODE_BLACKLIST_FLAG>& list_of_flags)
 {
-    return(count(l.being(), l.end(), mode) == 0);
+    //eturn(count(l.being(), l.end(), mode) == 0);
+    return std::count(list_of_flags.begin(), list_of_flags.end(), mode) > 0;
 }
 
 RobotDriverClient::RobotDriverClient(const std::shared_ptr<Node> &node,
@@ -86,7 +93,7 @@ RobotDriverClient::RobotDriverClient(const std::shared_ptr<Node> &node,
 {
     RCLCPP_INFO_STREAM(node_->get_logger(),"::Initializing RobotDriverClient with prefix " + topic_prefix);
 
-    if(mode_not_in_blacklist(MODE_BLACKLIST_FLAG::JOINT_CONTROL,blacklisted_modes_))
+    if(!mode_in_blacklist(MODE_BLACKLIST_FLAG::JOINT_CONTROL,blacklisted_modes_))
     {
         publisher_target_joint_positions_ = node->create_publisher<std_msgs::msg::Float64MultiArray>(topic_prefix + "/set/target_joint_positions",1);
         publisher_target_joint_velocities_ = node->create_publisher<std_msgs::msg::Float64MultiArray>(topic_prefix + "/set/target_joint_velocities",1);
@@ -95,12 +102,12 @@ RobotDriverClient::RobotDriverClient(const std::shared_ptr<Node> &node,
         publisher_clear_positions_signal_ = node->create_publisher<std_msgs::msg::Int32MultiArray>(topic_prefix + "/set/clear_positions_signal",1);
     }
 
-    if(mode_not_in_blacklist(MODE_BLACKLIST_FLAG::WATCHDOG_CONTROL,blacklisted_modes_))
+    if(!mode_in_blacklist(MODE_BLACKLIST_FLAG::WATCHDOG_CONTROL,blacklisted_modes_))
     {
         publisher_watchdog_trigger_ = node->create_publisher<sas_msgs::msg::WatchdogTrigger>(topic_prefix + "/set/watchdog_trigger", 1);
     }
 
-    if(mode_not_in_blacklist(MODE_BLACKLIST_FLAG::JOINT_MONITORING,blacklisted_modes_))
+    if(!mode_in_blacklist(MODE_BLACKLIST_FLAG::JOINT_MONITORING,blacklisted_modes_))
     {
         subscriber_joint_states_ = node->create_subscription<sensor_msgs::msg::JointState>(
                     topic_prefix + "/get/joint_states", 1, std::bind(&RobotDriverClient::_callback_joint_states, this, _1)

--- a/src/sas_robot_driver_py.cpp
+++ b/src/sas_robot_driver_py.cpp
@@ -47,7 +47,10 @@ PYBIND11_MODULE(_sas_robot_driver, m) {
             .export_values();
 
     py::class_<RDC>(m, "RobotDriverClient")
-            .def(py::init<const std::shared_ptr<rclcpp::Node>&,const std::string&>(),const std::vector<RDC::MODE_BLACKLIST_FLAG>&)
+            .def(py::init<const std::shared_ptr<rclcpp::Node>&, const std::string&,const std::vector<RDC::MODE_BLACKLIST_FLAG>&>(),
+                 py::arg("node"),
+                 py::arg("topic_prefix") = "GET_FROM_NODE",
+                 py::arg("blacklisted_modes") = std::vector<RDC::MODE_BLACKLIST_FLAG>{})
             .def("send_target_joint_positions",&RDC::send_target_joint_positions)
             .def("send_target_joint_velocities",&RDC::send_target_joint_velocities)
             .def("send_target_joint_forces",&RDC::send_target_joint_forces)

--- a/src/sas_robot_watchdog_commander_node.cpp
+++ b/src/sas_robot_watchdog_commander_node.cpp
@@ -55,7 +55,11 @@ int main(int argc, char** argv)
     RCLCPP_INFO_STREAM_ONCE(node->get_logger(), "::Parameters OK.");
 
     // Initialize the RobotDriverClient
-    sas::RobotDriverClient rdi(node, robot_name);
+    // This client is not allowed to command the robot joints. To achieve this behaviour,
+    // we blacklist the JOINT_CONTROL mode.
+    using MODE_BLACKLIST_FLAG = sas::RobotDriverClient::MODE_BLACKLIST_FLAG;
+    std::vector<MODE_BLACKLIST_FLAG> blacklist_mode = {MODE_BLACKLIST_FLAG::JOINT_CONTROL};
+    sas::RobotDriverClient rdi(node, robot_name, blacklist_mode);
 
 
     sas::Clock clock{thread_sampling_time_sec};


### PR DESCRIPTION
Hi @mmmarinho, 

This PR fixes the blacklist feature. I tested using a [SAS dummy driver](https://github.com/juanjqo/sas_robot_driver_dummy). However, I did not test on real platforms yet.
Furthermore, I did not test the Python version. 

Usage:

```cpp

RobotClientDummy::RobotClientDummy(std::shared_ptr<Node> &node,
                                   const RobotClientDummyConfiguration &configuration,
                                   std::atomic_bool *break_loops):
    configuration_(configuration),
    st_break_loops_{break_loops},
    node_{node},
    clock_{configuration.thread_sampling_time_sec}
{
    impl_ = std::make_unique<RobotClientDummy::Impl>();
   
    // This client is not allowed to command the watchdog. Therefore, this feature is blacklisted
    // Therefore, this rdi_->send_watchdog_trigger(false) does not have any effect
    std::vector<RobotDriverClient::MODE_BLACKLIST_FLAG> flags;
    flags.push_back(RobotDriverClient::MODE_BLACKLIST_FLAG::WATCHDOG_CONTROL);
    rdi_ = std::make_shared<sas::RobotDriverClient>(node_, configuration_.topic_prefix, flags);



    // This client is not allowed to command the joints. Therefore, this feature is blacklisted
    std::vector<RobotDriverClient::MODE_BLACKLIST_FLAG> flags2;
    flags2.push_back(RobotDriverClient::MODE_BLACKLIST_FLAG::JOINT_CONTROL);
    rdi_watchdog_ = std::make_shared<sas::RobotDriverClient>(node_, configuration_.topic_prefix, flags2);


    // This client is not allowed to command the joints or the watchdog. Therefore, these features are blacklisted
    std::vector<RobotDriverClient::MODE_BLACKLIST_FLAG> flags3;
    flags3.push_back(RobotDriverClient::MODE_BLACKLIST_FLAG::JOINT_CONTROL);
    flags3.push_back(RobotDriverClient::MODE_BLACKLIST_FLAG::WATCHDOG_CONTROL);
    rdi_monitoring_ = std::make_shared<sas::RobotDriverClient>(node_, configuration_.topic_prefix, flags3);


    // This is done to test if an exception is thrown.
    // rdi_2_ = std::make_shared<sas::RobotDriverClient>(node_, configuration_.topic_prefix, flags);


}
```

Kind regards, 

Juancho