### PR TITLE
All Watchdog parameters can now be set by the client

### DIFF
--- a/include/sas_robot_driver/sas_robot_driver_client.hpp
+++ b/include/sas_robot_driver/sas_robot_driver_client.hpp
@@ -97,7 +97,9 @@ public:
     void send_target_joint_forces(const VectorXd& target_joint_forces);
     void send_homing_signal(const VectorXi& homing_signal);
     void send_clear_positions_signal(const VectorXi& clear_positions_signal);
-    void send_watchdog_trigger(const bool& watchdog_trigger_status);
+    void send_watchdog_trigger(const bool& watchdog_trigger_status,
+                               const double& period_in_seconds = 1.0,
+                               const double& maximum_acceptable_delay = 0.5);
 
     VectorXd get_joint_positions() const;
     VectorXd get_joint_velocities() const;

--- a/include/sas_robot_driver/sas_robot_driver_ros.hpp
+++ b/include/sas_robot_driver/sas_robot_driver_ros.hpp
@@ -66,7 +66,8 @@ private:
     Clock clock_;
     RobotDriverServer robot_driver_server_;
     bool watchdog_started_;
-    std::string watchdog_parameter_name_{"watchdog_period_in_seconds"};
+    double watchdog_period_in_seconds_;
+    double watchdog_maximum_acceptable_delay_in_seconds_;
     bool _should_shutdown() const;
 
 public:

--- a/include/sas_robot_driver/sas_robot_driver_server.hpp
+++ b/include/sas_robot_driver/sas_robot_driver_server.hpp
@@ -72,6 +72,8 @@ private:
     Subscription<sas_msgs::msg::WatchdogTrigger>::SharedPtr subscriber_watchdog_trigger_;
     bool watchdog_trigger_status_;
     bool watchdog_enabled_;
+    double watchdog_period_in_seconds_;
+    double watchdog_maximum_acceptable_delay_in_seconds_;
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> time_point_from_the_client_;
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> time_point_from_the_server_;
 
@@ -112,6 +114,8 @@ public:
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> get_watchdog_time_point_from_the_server() const;
     bool get_watchdog_trigger_status() const;
     bool is_watchdog_enabled() const;
+    double get_watchdog_period() const;
+    double get_watchdog_maximum_acceptable_delay() const;
 };
 
 }

--- a/src/sas_robot_driver_client.cpp
+++ b/src/sas_robot_driver_client.cpp
@@ -190,8 +190,14 @@ void RobotDriverClient::send_clear_positions_signal(const VectorXi &clear_positi
 /**
  * @brief RobotDriverClient::send_watchdog_trigger sends the Watchdog trigger
  * @param watchdog_trigger_status The desired status for the Watchdog
+ * @param period_in_seconds The desired period in seconds.
+ * @param maximum_acceptable_delay. The maximum allowed difference between the timepoint sent by the client and the timepoint
+ *                                  registered by the server. This delay could be related to unsynchronised clocks between different computers
+ *                                  or network delays.
  */
-void RobotDriverClient::send_watchdog_trigger(const bool& watchdog_trigger_status)
+void RobotDriverClient::send_watchdog_trigger(const bool& watchdog_trigger_status,
+                                              const double &period_in_seconds,
+                                              const double &maximum_acceptable_delay)
 {
 
     if (publisher_watchdog_trigger_)
@@ -200,6 +206,8 @@ void RobotDriverClient::send_watchdog_trigger(const bool& watchdog_trigger_statu
         ros_msg.header = std_msgs::msg::Header();
         ros_msg.header.stamp = rclcpp::Clock().now();
         ros_msg.status = watchdog_trigger_status;
+        ros_msg.period_in_seconds = period_in_seconds;
+        ros_msg.maximum_acceptable_delay_in_seconds = maximum_acceptable_delay;
         publisher_watchdog_trigger_->publish(ros_msg);
     }
     else

--- a/src/sas_robot_driver_ros.cpp
+++ b/src/sas_robot_driver_ros.cpp
@@ -86,16 +86,16 @@ int RobotDriverROS::control_loop()
                 if (!watchdog_started_)
                 {   // This portion of code is executed only one time
                     // Initialize the watchdog.
-                    double watchdog_period;
-                    double watchdog_maximum_acceptable_delay;
+                    const double& watchdog_period = robot_driver_server_.get_watchdog_period();
+                    const double& watchdog_maximum_acceptable_delay = robot_driver_server_.get_watchdog_maximum_acceptable_delay();
                     // If the "watchdog_period_in_seconds" is not defined, we use a default value.
-                    get_ros_optional_parameter(node_, "watchdog_period_in_seconds", watchdog_period, 1.0);
+                    //get_ros_optional_parameter(node_, "watchdog_period_in_seconds", watchdog_period, 1.0);
                     RCLCPP_INFO_STREAM(node_->get_logger(), "::Watchdog initialized with a " << watchdog_period << " second period");
                     // If the elapsed time between the triggers is higher than the watchdog period, an exception is thrown
 
 
                     // If the "watchdog_maximum_acceptable_delay" is not defined, we use a default value.
-                    get_ros_optional_parameter(node_, "watchdog_maximum_acceptable_delay", watchdog_maximum_acceptable_delay, 1.0);
+                    //get_ros_optional_parameter(node_, "watchdog_maximum_acceptable_delay", watchdog_maximum_acceptable_delay, 1.0);
                     RCLCPP_INFO_STREAM(node_->get_logger(), "::Watchdog initialized with a maximum acceptable delay of " << watchdog_maximum_acceptable_delay<< " seconds");
                     // If the time difference between the time point of signal that was sent (using the client computer's clock) and the time point
                     // when the watchdog signal was received (using the computer's clock on which the server is running) is higher than the watchdog_maximum_acceptable_delay,

--- a/src/sas_robot_driver_ros.cpp
+++ b/src/sas_robot_driver_ros.cpp
@@ -88,14 +88,9 @@ int RobotDriverROS::control_loop()
                     // Initialize the watchdog.
                     const double& watchdog_period = robot_driver_server_.get_watchdog_period();
                     const double& watchdog_maximum_acceptable_delay = robot_driver_server_.get_watchdog_maximum_acceptable_delay();
-                    // If the "watchdog_period_in_seconds" is not defined, we use a default value.
-                    //get_ros_optional_parameter(node_, "watchdog_period_in_seconds", watchdog_period, 1.0);
                     RCLCPP_INFO_STREAM(node_->get_logger(), "::Watchdog initialized with a " << watchdog_period << " second period");
                     // If the elapsed time between the triggers is higher than the watchdog period, an exception is thrown
 
-
-                    // If the "watchdog_maximum_acceptable_delay" is not defined, we use a default value.
-                    //get_ros_optional_parameter(node_, "watchdog_maximum_acceptable_delay", watchdog_maximum_acceptable_delay, 1.0);
                     RCLCPP_INFO_STREAM(node_->get_logger(), "::Watchdog initialized with a maximum acceptable delay of " << watchdog_maximum_acceptable_delay<< " seconds");
                     // If the time difference between the time point of signal that was sent (using the client computer's clock) and the time point
                     // when the watchdog signal was received (using the computer's clock on which the server is running) is higher than the watchdog_maximum_acceptable_delay,

--- a/src/sas_robot_driver_ros.cpp
+++ b/src/sas_robot_driver_ros.cpp
@@ -34,6 +34,18 @@
 #include <dqrobotics/utils/DQ_Math.h>
 #include <dqrobotics/interfaces/json11/DQ_JsonReader.h>
 
+/**
+ * @brief are_approximately_equal returns true if two doubles are approximately equal.
+ * @param a
+ * @param b
+ * @param epsilon The desired threshold
+ * @return a boolean flag
+ */
+bool are_approximately_equal(const double &a, const double &b, const double &epsilon)
+{
+    return std::abs(a - b) < epsilon;
+}
+
 namespace sas
 {
 
@@ -107,11 +119,12 @@ int RobotDriverROS::control_loop()
                     //--- For developers: Do not put more code after this point---//
                 }else{
                     // Check if the period and the maximum acceptable delay changed.
-                    if (watchdog_period_in_seconds_ != robot_driver_server_.get_watchdog_period())
+                    if (!are_approximately_equal(watchdog_period_in_seconds_,robot_driver_server_.get_watchdog_period(), DQ_robotics::DQ_threshold))
                         throw std::runtime_error("Invalid operation. The watchdog period changed from "+std::to_string(watchdog_period_in_seconds_)+
                                                  " to " +std::to_string(robot_driver_server_.get_watchdog_period()));
 
-                    if (watchdog_maximum_acceptable_delay_in_seconds_!= robot_driver_server_.get_watchdog_period())
+
+                    if (!are_approximately_equal(watchdog_maximum_acceptable_delay_in_seconds_, robot_driver_server_.get_watchdog_maximum_acceptable_delay(), DQ_robotics::DQ_threshold))
                         throw std::runtime_error("Invalid operation. The watchdog maximum acceptable delay changed from "+std::to_string(watchdog_maximum_acceptable_delay_in_seconds_)+
                                                  " to " +std::to_string(robot_driver_server_.get_watchdog_maximum_acceptable_delay()));
                 }

--- a/src/sas_robot_driver_ros.cpp
+++ b/src/sas_robot_driver_ros.cpp
@@ -86,24 +86,34 @@ int RobotDriverROS::control_loop()
                 if (!watchdog_started_)
                 {   // This portion of code is executed only one time
                     // Initialize the watchdog.
-                    const double& watchdog_period = robot_driver_server_.get_watchdog_period();
-                    const double& watchdog_maximum_acceptable_delay = robot_driver_server_.get_watchdog_maximum_acceptable_delay();
-                    RCLCPP_INFO_STREAM(node_->get_logger(), "::Watchdog initialized with a " << watchdog_period << " second period");
+                    watchdog_period_in_seconds_                   = robot_driver_server_.get_watchdog_period();
+                    watchdog_maximum_acceptable_delay_in_seconds_ = robot_driver_server_.get_watchdog_maximum_acceptable_delay();
+
+                    RCLCPP_INFO_STREAM(node_->get_logger(), "::Watchdog initialized with a " << watchdog_period_in_seconds_  << " second period");
                     // If the elapsed time between the triggers is higher than the watchdog period, an exception is thrown
 
-                    RCLCPP_INFO_STREAM(node_->get_logger(), "::Watchdog initialized with a maximum acceptable delay of " << watchdog_maximum_acceptable_delay<< " seconds");
+                    RCLCPP_INFO_STREAM(node_->get_logger(), "::Watchdog initialized with a maximum acceptable delay of " <<watchdog_maximum_acceptable_delay_in_seconds_<< " seconds");
                     // If the time difference between the time point of signal that was sent (using the client computer's clock) and the time point
                     // when the watchdog signal was received (using the computer's clock on which the server is running) is higher than the watchdog_maximum_acceptable_delay,
                     // an exception is thrown by the robot driver.
 
                     const std::chrono::nanoseconds period = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                        std::chrono::duration<double>(watchdog_period));
+                        std::chrono::duration<double>(watchdog_period_in_seconds_));
                     watchdog_started_ = true;
-                    robot_driver_->watchdog_set_maximum_acceptable_delay(watchdog_maximum_acceptable_delay);
+                    robot_driver_->watchdog_set_maximum_acceptable_delay(watchdog_maximum_acceptable_delay_in_seconds_);
 
                     //-----------------------------------------------------------------------------------------/
                     robot_driver_->watchdog_start(period);
                     //--- For developers: Do not put more code after this point---//
+                }else{
+                    // Check if the period and the maximum acceptable delay changed.
+                    if (watchdog_period_in_seconds_ != robot_driver_server_.get_watchdog_period())
+                        throw std::runtime_error("Invalid operation. The watchdog period changed from "+std::to_string(watchdog_period_in_seconds_)+
+                                                 " to " +std::to_string(robot_driver_server_.get_watchdog_period()));
+
+                    if (watchdog_maximum_acceptable_delay_in_seconds_!= robot_driver_server_.get_watchdog_period())
+                        throw std::runtime_error("Invalid operation. The watchdog maximum acceptable delay changed from "+std::to_string(watchdog_maximum_acceptable_delay_in_seconds_)+
+                                                 " to " +std::to_string(robot_driver_server_.get_watchdog_maximum_acceptable_delay()));
                 }
                 
                 try{robot_driver_->watchdog_trigger(robot_driver_server_.get_watchdog_time_point_from_the_client(),

--- a/src/sas_robot_driver_server.cpp
+++ b/src/sas_robot_driver_server.cpp
@@ -100,6 +100,10 @@ void RobotDriverServer::_callback_clear_positions_signal(const std_msgs::msg::In
 
 void RobotDriverServer::_callback_watchdog_trigger_state(const sas_msgs::msg::WatchdogTrigger &msg)
 {
+    const std::string this_topic(node_prefix_ + "/set/watchdog_trigger");
+    if(node_->count_publishers(this_topic)>1)
+        throw std::runtime_error(this_topic + " must be exclusively published and there is more than one publisher connected.");
+
     watchdog_enabled_ = true;
     watchdog_trigger_status_ = msg.status;
     watchdog_period_in_seconds_ = msg.period_in_seconds;

--- a/src/sas_robot_driver_server.cpp
+++ b/src/sas_robot_driver_server.cpp
@@ -102,6 +102,8 @@ void RobotDriverServer::_callback_watchdog_trigger_state(const sas_msgs::msg::Wa
 {
     watchdog_enabled_ = true;
     watchdog_trigger_status_ = msg.status;
+    watchdog_period_in_seconds_ = msg.period_in_seconds;
+    watchdog_maximum_acceptable_delay_in_seconds_ = msg.maximum_acceptable_delay_in_seconds;
 
     //This time point corresponds to the moment the signal was sent, as recorded by the client computer's clock.
     time_point_from_the_client_ = std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>(
@@ -308,6 +310,26 @@ bool RobotDriverServer::get_watchdog_trigger_status() const
 bool RobotDriverServer::is_watchdog_enabled() const
 {
     return watchdog_enabled_;
+}
+
+/**
+ * @brief RobotDriverServer::get_watchdog_period returns the watchdog period
+ * @return The watchdog period in seconds.
+ */
+double RobotDriverServer::get_watchdog_period() const
+{
+    return watchdog_period_in_seconds_;
+}
+
+/**
+ * @brief RobotDriverServer::get_watchdog_maximum_acceptable_delay returns the maximum acceptable delay in seconds.
+ *                          This delay could be related to unsynchronised clocks between different computers
+ *                          or network delays.
+ * @return returns the maximum acceptable delay in seconds.
+ */
+double RobotDriverServer::get_watchdog_maximum_acceptable_delay() const
+{
+    return watchdog_maximum_acceptable_delay_in_seconds_;
 }
 
 

--- a/src/sas_robot_watchdog_commander_node.cpp
+++ b/src/sas_robot_watchdog_commander_node.cpp
@@ -48,6 +48,13 @@ int main(int argc, char** argv)
 
     double thread_sampling_time_sec;
     sas::get_ros_parameter(node, "thread_sampling_time_sec", thread_sampling_time_sec);
+
+    double period;
+    sas::get_ros_parameter(node, "watchdog_period", period);
+
+    double maximum_acceptable_delay;
+    sas::get_ros_parameter(node, "watchdog_maximum_acceptable_delay", maximum_acceptable_delay);
+
     std::string robot_name;
     sas::get_ros_parameter(node,"robot_name", robot_name);
     RCLCPP_INFO_STREAM_ONCE(node->get_logger(), "::thread_sampling_time_sec: " + std::to_string(thread_sampling_time_sec));
@@ -69,7 +76,7 @@ int main(int argc, char** argv)
     {
         clock.update_and_sleep();
         RCLCPP_INFO_STREAM_ONCE(node->get_logger(),"Watchdog status: true");
-        rdi.send_watchdog_trigger(true);
+        rdi.send_watchdog_trigger(true, period, maximum_acceptable_delay);
         rclcpp::spin_some(node);
     }
 


### PR DESCRIPTION
Hi @mmmarinho, 

This PR removes the option to set the watchdog parameters on the server side. Instead, all parameters can now be set by the client. Furthermore, SAS now allows only one publisher for the Watchdog signal.

Kind regards, 

Juancho