### PR TITLE
This PR adds methods to shut down the server 

### DIFF
--- a/include/sas_robot_driver/sas_robot_driver_client.hpp
+++ b/include/sas_robot_driver/sas_robot_driver_client.hpp
@@ -40,7 +40,8 @@
 #include <sas_msgs/msg/watchdog_trigger.hpp>
 #include <sas_core/sas_robot_driver.hpp>
 #include <sas_core/sas_object.hpp>
-#include <std_msgs/msg/bool.hpp>
+#include <sas_msgs/msg/bool.hpp>
+
 
 using namespace rclcpp;
 
@@ -80,7 +81,7 @@ private:
     Publisher<std_msgs::msg::Int32MultiArray>  ::SharedPtr publisher_homing_signal_;
     Publisher<std_msgs::msg::Int32MultiArray>  ::SharedPtr publisher_clear_positions_signal_;
     Publisher<sas_msgs::msg::WatchdogTrigger>  ::SharedPtr publisher_watchdog_trigger_;
-    Publisher<std_msgs::msg::Bool>             ::SharedPtr publisher_shutdown_signal_;
+    Publisher<sas_msgs::msg::Bool>             ::SharedPtr publisher_shutdown_signal_;
 
     void _callback_joint_states(const sensor_msgs::msg::JointState& msg);
     void _callback_joint_limits_min(const std_msgs::msg::Float64MultiArray& msg);

--- a/include/sas_robot_driver/sas_robot_driver_client.hpp
+++ b/include/sas_robot_driver/sas_robot_driver_client.hpp
@@ -80,7 +80,7 @@ private:
     Publisher<std_msgs::msg::Int32MultiArray>  ::SharedPtr publisher_homing_signal_;
     Publisher<std_msgs::msg::Int32MultiArray>  ::SharedPtr publisher_clear_positions_signal_;
     Publisher<sas_msgs::msg::WatchdogTrigger>  ::SharedPtr publisher_watchdog_trigger_;
-    Publisher<std_msgs::msg::Bool>             ::SharedPtr publisher_target_shutdown_command_;
+    Publisher<std_msgs::msg::Bool>             ::SharedPtr publisher_shutdown_signal_;
 
     void _callback_joint_states(const sensor_msgs::msg::JointState& msg);
     void _callback_joint_limits_min(const std_msgs::msg::Float64MultiArray& msg);
@@ -103,7 +103,7 @@ public:
                                const double& period_in_seconds = 1.0,
                                const double& maximum_acceptable_delay = 0.5);
 
-    void send_shutdown();
+    void send_shutdown_signal();
 
     VectorXd get_joint_positions() const;
     VectorXd get_joint_velocities() const;

--- a/include/sas_robot_driver/sas_robot_driver_client.hpp
+++ b/include/sas_robot_driver/sas_robot_driver_client.hpp
@@ -40,6 +40,7 @@
 #include <sas_msgs/msg/watchdog_trigger.hpp>
 #include <sas_core/sas_robot_driver.hpp>
 #include <sas_core/sas_object.hpp>
+#include <std_msgs/msg/bool.hpp>
 
 using namespace rclcpp;
 
@@ -79,6 +80,7 @@ private:
     Publisher<std_msgs::msg::Int32MultiArray>  ::SharedPtr publisher_homing_signal_;
     Publisher<std_msgs::msg::Int32MultiArray>  ::SharedPtr publisher_clear_positions_signal_;
     Publisher<sas_msgs::msg::WatchdogTrigger>  ::SharedPtr publisher_watchdog_trigger_;
+    Publisher<std_msgs::msg::Bool>             ::SharedPtr publisher_target_shutdown_command_;
 
     void _callback_joint_states(const sensor_msgs::msg::JointState& msg);
     void _callback_joint_limits_min(const std_msgs::msg::Float64MultiArray& msg);
@@ -100,6 +102,8 @@ public:
     void send_watchdog_trigger(const bool& watchdog_trigger_status,
                                const double& period_in_seconds = 1.0,
                                const double& maximum_acceptable_delay = 0.5);
+
+    void send_shutdown();
 
     VectorXd get_joint_positions() const;
     VectorXd get_joint_velocities() const;

--- a/include/sas_robot_driver/sas_robot_driver_server.hpp
+++ b/include/sas_robot_driver/sas_robot_driver_server.hpp
@@ -40,6 +40,7 @@
 #include <sas_core/sas_robot_driver.hpp>
 #include <sas_core/sas_object.hpp>
 #include <sas_msgs/msg/watchdog_trigger.hpp>
+#include <std_msgs/msg/bool.hpp>
 
 using namespace rclcpp;
 
@@ -59,6 +60,9 @@ private:
     Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr publisher_joint_limits_max_;
     Publisher<std_msgs::msg::Int32MultiArray>::SharedPtr publisher_home_state_;
 
+
+    Subscription<std_msgs::msg::Bool>::SharedPtr subscriber_target_shutdown_command_;
+    bool target_shutdown_;
     Subscription<std_msgs::msg::Float64MultiArray>::SharedPtr subscriber_target_joint_positions_;
     VectorXd target_joint_positions_;
     Subscription<std_msgs::msg::Float64MultiArray>::SharedPtr subscriber_target_joint_velocities_;
@@ -77,7 +81,7 @@ private:
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> time_point_from_the_client_;
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> time_point_from_the_server_;
 
-
+    void _callback_target_shutdown_command(const std_msgs::msg::Bool& msg);
     void _callback_target_joint_positions(const std_msgs::msg::Float64MultiArray &msg);
     void _callback_target_joint_velocities(const std_msgs::msg::Float64MultiArray &msg);
     void _callback_target_joint_forces(const std_msgs::msg::Float64MultiArray &msg);
@@ -116,6 +120,7 @@ public:
     bool is_watchdog_enabled() const;
     double get_watchdog_period() const;
     double get_watchdog_maximum_acceptable_delay() const;
+    bool get_shutdown_status() const;
 };
 
 }

--- a/include/sas_robot_driver/sas_robot_driver_server.hpp
+++ b/include/sas_robot_driver/sas_robot_driver_server.hpp
@@ -40,7 +40,7 @@
 #include <sas_core/sas_robot_driver.hpp>
 #include <sas_core/sas_object.hpp>
 #include <sas_msgs/msg/watchdog_trigger.hpp>
-#include <std_msgs/msg/bool.hpp>
+#include <sas_msgs/msg/bool.hpp>
 
 using namespace rclcpp;
 
@@ -61,7 +61,7 @@ private:
     Publisher<std_msgs::msg::Int32MultiArray>::SharedPtr publisher_home_state_;
 
 
-    Subscription<std_msgs::msg::Bool>::SharedPtr subscriber_shutdown_signal_;
+    Subscription<sas_msgs::msg::Bool>::SharedPtr subscriber_shutdown_signal_;
     bool shutdown_signal_;
     Subscription<std_msgs::msg::Float64MultiArray>::SharedPtr subscriber_target_joint_positions_;
     VectorXd target_joint_positions_;
@@ -81,7 +81,7 @@ private:
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> time_point_from_the_client_;
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> time_point_from_the_server_;
 
-    void _callback_shutdown_signal_(const std_msgs::msg::Bool& msg);
+    void _callback_shutdown_signal_(const sas_msgs::msg::Bool& msg);
     void _callback_target_joint_positions(const std_msgs::msg::Float64MultiArray &msg);
     void _callback_target_joint_velocities(const std_msgs::msg::Float64MultiArray &msg);
     void _callback_target_joint_forces(const std_msgs::msg::Float64MultiArray &msg);

--- a/include/sas_robot_driver/sas_robot_driver_server.hpp
+++ b/include/sas_robot_driver/sas_robot_driver_server.hpp
@@ -61,7 +61,7 @@ private:
     Publisher<std_msgs::msg::Int32MultiArray>::SharedPtr publisher_home_state_;
 
 
-    Subscription<std_msgs::msg::Bool>::SharedPtr subscriber_target_shutdown_command_;
+    Subscription<std_msgs::msg::Bool>::SharedPtr subscriber_shutdown_signal_;
     bool target_shutdown_;
     Subscription<std_msgs::msg::Float64MultiArray>::SharedPtr subscriber_target_joint_positions_;
     VectorXd target_joint_positions_;

--- a/include/sas_robot_driver/sas_robot_driver_server.hpp
+++ b/include/sas_robot_driver/sas_robot_driver_server.hpp
@@ -62,7 +62,7 @@ private:
 
 
     Subscription<std_msgs::msg::Bool>::SharedPtr subscriber_shutdown_signal_;
-    bool target_shutdown_;
+    bool shutdown_signal_;
     Subscription<std_msgs::msg::Float64MultiArray>::SharedPtr subscriber_target_joint_positions_;
     VectorXd target_joint_positions_;
     Subscription<std_msgs::msg::Float64MultiArray>::SharedPtr subscriber_target_joint_velocities_;
@@ -81,7 +81,7 @@ private:
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> time_point_from_the_client_;
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> time_point_from_the_server_;
 
-    void _callback_target_shutdown_command(const std_msgs::msg::Bool& msg);
+    void _callback_shutdown_signal_(const std_msgs::msg::Bool& msg);
     void _callback_target_joint_positions(const std_msgs::msg::Float64MultiArray &msg);
     void _callback_target_joint_velocities(const std_msgs::msg::Float64MultiArray &msg);
     void _callback_target_joint_forces(const std_msgs::msg::Float64MultiArray &msg);
@@ -120,7 +120,7 @@ public:
     bool is_watchdog_enabled() const;
     double get_watchdog_period() const;
     double get_watchdog_maximum_acceptable_delay() const;
-    bool get_shutdown_status() const;
+    bool get_shutdown_signal() const;
 };
 
 }

--- a/src/sas_robot_driver_client.cpp
+++ b/src/sas_robot_driver_client.cpp
@@ -123,7 +123,7 @@ RobotDriverClient::RobotDriverClient(const std::shared_ptr<Node> &node,
                     );
     }
     // All client types can shut down the server.
-    publisher_shutdown_signal_ = node->create_publisher<std_msgs::msg::Bool>(topic_prefix + "/set/shutdown", 1);
+    publisher_shutdown_signal_ = node->create_publisher<sas_msgs::msg::Bool>(topic_prefix + "/set/shutdown", 1);
 }
 
 void RobotDriverClient::send_target_joint_positions(const VectorXd &target_joint_positions)
@@ -221,7 +221,7 @@ void RobotDriverClient::send_watchdog_trigger(const bool& watchdog_trigger_statu
  */
 void RobotDriverClient::send_shutdown_signal()
 {
-    std_msgs::msg::Bool ros_msg;
+    sas_msgs::msg::Bool ros_msg;
     ros_msg.data = true;
     publisher_shutdown_signal_->publish(ros_msg);
 }

--- a/src/sas_robot_driver_client.cpp
+++ b/src/sas_robot_driver_client.cpp
@@ -123,7 +123,7 @@ RobotDriverClient::RobotDriverClient(const std::shared_ptr<Node> &node,
                     );
     }
     // All client types can shut down the server.
-    publisher_target_shutdown_command_ = node->create_publisher<std_msgs::msg::Bool>(topic_prefix + "/set/shutdown", 1);
+    publisher_shutdown_signal_ = node->create_publisher<std_msgs::msg::Bool>(topic_prefix + "/set/shutdown", 1);
 }
 
 void RobotDriverClient::send_target_joint_positions(const VectorXd &target_joint_positions)
@@ -217,13 +217,13 @@ void RobotDriverClient::send_watchdog_trigger(const bool& watchdog_trigger_statu
 }
 
 /**
- * @brief RobotDriverClient::send_shutdown this method sends a command to stop the server.
+ * @brief RobotDriverClient::send_shutdown_signal this method sends a signal to stop the server.
  */
-void RobotDriverClient::send_shutdown()
+void RobotDriverClient::send_shutdown_signal()
 {
     std_msgs::msg::Bool ros_msg;
     ros_msg.data = true;
-    publisher_target_shutdown_command_->publish(ros_msg);
+    publisher_shutdown_signal_->publish(ros_msg);
 }
 
 VectorXd RobotDriverClient::get_joint_positions() const

--- a/src/sas_robot_driver_client.cpp
+++ b/src/sas_robot_driver_client.cpp
@@ -122,6 +122,8 @@ RobotDriverClient::RobotDriverClient(const std::shared_ptr<Node> &node,
                     topic_prefix + "/get/home_states", 1, std::bind(&RobotDriverClient::_callback_home_states, this, _1)
                     );
     }
+    // All client types can shut down the server.
+    publisher_target_shutdown_command_ = node->create_publisher<std_msgs::msg::Bool>(topic_prefix + "/set/shutdown", 1);
 }
 
 void RobotDriverClient::send_target_joint_positions(const VectorXd &target_joint_positions)
@@ -212,6 +214,16 @@ void RobotDriverClient::send_watchdog_trigger(const bool& watchdog_trigger_statu
     }
     else
         throw std::runtime_error("RobotDriverClient::"+std::string(__FUNCTION__)+"::This method is blacklisted");
+}
+
+/**
+ * @brief RobotDriverClient::send_shutdown this method sends a command to stop the server.
+ */
+void RobotDriverClient::send_shutdown()
+{
+    std_msgs::msg::Bool ros_msg;
+    ros_msg.data = true;
+    publisher_target_shutdown_command_->publish(ros_msg);
 }
 
 VectorXd RobotDriverClient::get_joint_positions() const

--- a/src/sas_robot_driver_ros.cpp
+++ b/src/sas_robot_driver_ros.cpp
@@ -83,7 +83,7 @@ int RobotDriverROS::control_loop()
 
 
             if (robot_driver_server_.get_shutdown_signal())
-                throw std::runtime_error("The shutdown command was received!");
+                throw std::runtime_error("The shutdown signal was received!");
 
             if(robot_driver_server_.is_enabled())
             {

--- a/src/sas_robot_driver_ros.cpp
+++ b/src/sas_robot_driver_ros.cpp
@@ -82,7 +82,7 @@ int RobotDriverROS::control_loop()
             rclcpp::spin_some(node_);
 
 
-            if (robot_driver_server_.get_shutdown_status())
+            if (robot_driver_server_.get_shutdown_signal())
                 throw std::runtime_error("The shutdown command was received!");
 
             if(robot_driver_server_.is_enabled())

--- a/src/sas_robot_driver_ros.cpp
+++ b/src/sas_robot_driver_ros.cpp
@@ -81,6 +81,10 @@ int RobotDriverROS::control_loop()
             clock_.update_and_sleep();
             rclcpp::spin_some(node_);
 
+
+            if (robot_driver_server_.get_shutdown_status())
+                throw std::runtime_error("The shutdown command was received!");
+
             if(robot_driver_server_.is_enabled())
             {
                 robot_driver_->set_target_joint_positions(robot_driver_server_.get_target_joint_positions());

--- a/src/sas_robot_driver_server.cpp
+++ b/src/sas_robot_driver_server.cpp
@@ -159,7 +159,7 @@ RobotDriverServer::RobotDriverServer(const std::shared_ptr<Node> &node, const st
     subscriber_watchdog_trigger_ = node->create_subscription<sas_msgs::msg::WatchdogTrigger>(
         topic_prefix + "/set/watchdog_trigger", 1, std::bind(&RobotDriverServer::_callback_watchdog_trigger_state, this, _1)
         );
-    subscriber_target_shutdown_command_ = node->create_subscription<std_msgs::msg::Bool>(
+    subscriber_shutdown_signal_ = node->create_subscription<std_msgs::msg::Bool>(
          topic_prefix + "/set/shutdown", 1, std::bind(&RobotDriverServer::_callback_target_shutdown_command, this, _1)
         );
 }

--- a/src/sas_robot_driver_server.cpp
+++ b/src/sas_robot_driver_server.cpp
@@ -38,12 +38,12 @@ namespace sas
 {
 
 
-void RobotDriverServer::_callback_target_shutdown_command(const std_msgs::msg::Bool& msg)
+void RobotDriverServer::_callback_shutdown_signal_(const std_msgs::msg::Bool& msg)
 {
-    // Only update this member if never was set to true. In other words, the driver is
-    // shutdown if at least one received message is true.
-    if (target_shutdown_ == false)
-        target_shutdown_ = msg.data;
+   // Only update this member if it was never set to true.
+   // In other words, the driver is shut down if at least one received message is true.
+    if (shutdown_signal_ == false)
+        shutdown_signal_ = msg.data;
 }
 
 void RobotDriverServer::_callback_target_joint_positions(const std_msgs::msg::Float64MultiArray& msg)
@@ -131,7 +131,7 @@ RobotDriverServer::RobotDriverServer(const std::shared_ptr<Node> &node, const st
     node_(node),
     node_prefix_(topic_prefix == "GET_FROM_NODE"? node->get_name() : topic_prefix),
     currently_active_functionality_(RobotDriver::Functionality::None),
-    target_shutdown_{false},
+    shutdown_signal_{false},
     watchdog_enabled_{false}
 {
     RCLCPP_INFO_STREAM_ONCE(node->get_logger(), "::Initializing RobotDriverServer with prefix " + topic_prefix);
@@ -160,7 +160,7 @@ RobotDriverServer::RobotDriverServer(const std::shared_ptr<Node> &node, const st
         topic_prefix + "/set/watchdog_trigger", 1, std::bind(&RobotDriverServer::_callback_watchdog_trigger_state, this, _1)
         );
     subscriber_shutdown_signal_ = node->create_subscription<std_msgs::msg::Bool>(
-         topic_prefix + "/set/shutdown", 1, std::bind(&RobotDriverServer::_callback_target_shutdown_command, this, _1)
+         topic_prefix + "/set/shutdown", 1, std::bind(&RobotDriverServer::_callback_shutdown_signal_, this, _1)
         );
 }
 
@@ -348,9 +348,14 @@ double RobotDriverServer::get_watchdog_maximum_acceptable_delay() const
     return watchdog_maximum_acceptable_delay_in_seconds_;
 }
 
-bool RobotDriverServer::get_shutdown_status() const
+/**
+ * @brief RobotDriverServer::get_shutdown_signal returns the shutdown signal sent by the client. If no client sent any
+ *                signal, this method returns false.
+ * @return The desired signal.
+ */
+bool RobotDriverServer::get_shutdown_signal() const
 {
-    return target_shutdown_;
+    return shutdown_signal_;
 }
 
 

--- a/src/sas_robot_driver_server.cpp
+++ b/src/sas_robot_driver_server.cpp
@@ -38,7 +38,7 @@ namespace sas
 {
 
 
-void RobotDriverServer::_callback_shutdown_signal_(const std_msgs::msg::Bool& msg)
+void RobotDriverServer::_callback_shutdown_signal_(const sas_msgs::msg::Bool &msg)
 {
    // Only update this member if it was never set to true.
    // In other words, the driver is shut down if at least one received message is true.
@@ -159,7 +159,7 @@ RobotDriverServer::RobotDriverServer(const std::shared_ptr<Node> &node, const st
     subscriber_watchdog_trigger_ = node->create_subscription<sas_msgs::msg::WatchdogTrigger>(
         topic_prefix + "/set/watchdog_trigger", 1, std::bind(&RobotDriverServer::_callback_watchdog_trigger_state, this, _1)
         );
-    subscriber_shutdown_signal_ = node->create_subscription<std_msgs::msg::Bool>(
+    subscriber_shutdown_signal_ = node->create_subscription<sas_msgs::msg::Bool>(
          topic_prefix + "/set/shutdown", 1, std::bind(&RobotDriverServer::_callback_shutdown_signal_, this, _1)
         );
 }

--- a/src/sas_robot_driver_server.cpp
+++ b/src/sas_robot_driver_server.cpp
@@ -38,6 +38,14 @@ namespace sas
 {
 
 
+void RobotDriverServer::_callback_target_shutdown_command(const std_msgs::msg::Bool& msg)
+{
+    // Only update this member if never was set to true. In other words, the driver is
+    // shutdown if at least one received message is true.
+    if (target_shutdown_ == false)
+        target_shutdown_ = msg.data;
+}
+
 void RobotDriverServer::_callback_target_joint_positions(const std_msgs::msg::Float64MultiArray& msg)
 {
     const std::string this_topic(node_prefix_ + "/set/target_joint_positions");
@@ -123,6 +131,7 @@ RobotDriverServer::RobotDriverServer(const std::shared_ptr<Node> &node, const st
     node_(node),
     node_prefix_(topic_prefix == "GET_FROM_NODE"? node->get_name() : topic_prefix),
     currently_active_functionality_(RobotDriver::Functionality::None),
+    target_shutdown_{false},
     watchdog_enabled_{false}
 {
     RCLCPP_INFO_STREAM_ONCE(node->get_logger(), "::Initializing RobotDriverServer with prefix " + topic_prefix);
@@ -149,6 +158,9 @@ RobotDriverServer::RobotDriverServer(const std::shared_ptr<Node> &node, const st
                 );
     subscriber_watchdog_trigger_ = node->create_subscription<sas_msgs::msg::WatchdogTrigger>(
         topic_prefix + "/set/watchdog_trigger", 1, std::bind(&RobotDriverServer::_callback_watchdog_trigger_state, this, _1)
+        );
+    subscriber_target_shutdown_command_ = node->create_subscription<std_msgs::msg::Bool>(
+         topic_prefix + "/set/shutdown", 1, std::bind(&RobotDriverServer::_callback_target_shutdown_command, this, _1)
         );
 }
 
@@ -334,6 +346,11 @@ double RobotDriverServer::get_watchdog_period() const
 double RobotDriverServer::get_watchdog_maximum_acceptable_delay() const
 {
     return watchdog_maximum_acceptable_delay_in_seconds_;
+}
+
+bool RobotDriverServer::get_shutdown_status() const
+{
+    return target_shutdown_;
 }
 
 


### PR DESCRIPTION

Hi @mmmarinho. This PR adds an alternative way to shut down the server. The current way to shut down the server relies on a user-interruption signal or the recently added watchdog protocol. This latter can only be commanded by just one client, for safety reasons. In some scenarios, it could be helpful to have more than one client able to stop the robot.  

Kind regards, 

Juancho